### PR TITLE
Linux compatibility

### DIFF
--- a/QRGen/GridSVG/GridSVG.ElementCluster.swift
+++ b/QRGen/GridSVG/GridSVG.ElementCluster.swift
@@ -95,6 +95,13 @@ extension GridSVG.ElementCluster {
 			self.endpoints = [curve.start, curve.end]
 		}
 	}
+	private struct Index: Comparable, Equatable, Hashable {
+		let curve: Int
+		let element: Int
+		static func < (lhs: Self, rhs: Self) -> Bool {
+			lhs.element == rhs.element ? lhs.curve < rhs.curve : lhs.element < rhs.element
+		}
+	}
 	
 	/// The SVG paths making up the combined shape of the cluster's elements
 	func combinedPaths() -> [GridSVG.Path] {
@@ -102,7 +109,7 @@ extension GridSVG.ElementCluster {
 			return elements.map(\.path)
 		}
 		
-		var boundaryCurvesIndices = [CurveEndpoints: IndexPath]()
+		var boundaryCurvesIndices = [CurveEndpoints: Index]()
 		var boundaryCurvesEndpoints = [DecimalPoint: [CurveEndpoints]]()
 		var boundaryPaths = [GridSVG.Path]()
 		
@@ -111,7 +118,7 @@ extension GridSVG.ElementCluster {
 			for (curveIndex, curve) in element.path.curves.enumerated() {
 				let endpoints = CurveEndpoints(curve: curve)
 				guard boundaryCurvesIndices.removeValue(forKey: endpoints) == nil else { continue }
-				boundaryCurvesIndices[endpoints] = IndexPath(item: curveIndex, section: elementIndex)
+				boundaryCurvesIndices[endpoints] = Index(curve: curveIndex, element: elementIndex)
 			}
 		}
 		
@@ -128,10 +135,10 @@ extension GridSVG.ElementCluster {
 			let startIndex = boundaryCurvesIndices.removeValue(forKey: startCurveEndpoints)!
 			
 			var curves = [GridSVG.Curve]()
-			var nextIndex: IndexPath? = startIndex
-			var nextStartPoint = elements[startIndex.section].path.curves[startIndex.item].end
+			var nextIndex: Index? = startIndex
+			var nextStartPoint = elements[startIndex.element].path.curves[startIndex.curve].end
 			while let index = nextIndex { 
-				var curve = elements[index.section].path.curves[index.item]
+				var curve = elements[index.element].path.curves[index.curve]
 				// Reverse curve if necessary
 				if curve.start != nextStartPoint {
 					curve = curve.reverse()

--- a/QRGen/QRCode/BCQRCode.swift
+++ b/QRGen/QRCode/BCQRCode.swift
@@ -6,14 +6,18 @@
 //
 
 import Foundation
+#if canImport(AppKit)
 import AppKit
+#endif
 import struct QRCodeGenerator.QRCode
 
 typealias BCQRCode = QRCode
 
 extension BCQRCode: QRCodeProtocol {
+	#if canImport(AppKit)
 	var cgimage: CGImage {
 		let nsimage = self.makeImage(border: 0)
 		return nsimage.cgImage(forProposedRect: nil, context: nil, hints: nil)!
 	}
+	#endif
 }

--- a/QRGen/QRCode/CIQRCode.swift
+++ b/QRGen/QRCode/CIQRCode.swift
@@ -5,6 +5,7 @@
 //  Created by Max-Joseph on 15.08.22.
 //
 
+#if canImport(CoreImage)
 import Foundation
 import CoreImage
 
@@ -42,3 +43,4 @@ struct CIQRCode: QRCodeProtocol {
 		}
 	}
 }
+#endif

--- a/QRGen/QRCode/CIQRCodeGenerator.swift
+++ b/QRGen/QRCode/CIQRCodeGenerator.swift
@@ -5,6 +5,7 @@
 //  Created by Max-Joseph on 14.08.22.
 //
 
+#if canImport(CoreImage)
 import Foundation
 import CoreImage
 
@@ -77,3 +78,4 @@ extension CIQRCodeGenerator {
 		}
 	}
 }
+#endif

--- a/QRGen/QRCode/QRCodeProtocol.swift
+++ b/QRGen/QRCode/QRCodeProtocol.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
-import CoreImage
+#if canImport(AppKit)
+import CoreGraphics
+#endif
 
 
 protocol QRCodeProtocol {
@@ -16,8 +18,10 @@ protocol QRCodeProtocol {
 	/// The width and height of this QR Code, measured in modules, between 21 and 177 (inclusive). This is equal to version * 4 + 17.
 	var size: Int { get }
 	
+	#if canImport(AppKit)
 	/// The QR code drawn as a bitmap image where each module is exactly one black or white pixel (without a border).
 	var cgimage: CGImage { get }
+	#endif
 	
 	/// The modules of this QR Code (false = white, true = black).
 	subscript(_ x: Int, _ y: Int) -> Bool { get }

--- a/QRGen/QRGen.swift
+++ b/QRGen/QRGen.swift
@@ -6,8 +6,9 @@
 //
 
 import Foundation
+#if canImport(AppKit)
 import CoreImage
-
+#endif
 
 struct QRGen {
 	let outputURL: URL
@@ -29,7 +30,9 @@ struct QRGen {
 		case text(String)
 	}
 	enum GeneratorType: String, ArgumentEnum {
+		#if canImport(CoreImage)
 		case coreImage
+		#endif
 		case nayuki
 	}
 	enum Style: String, ArgumentEnum {
@@ -67,14 +70,18 @@ struct QRGen {
 			
 			// Create PNG (1px scale)
 			if writePNG {
+				#if canImport(AppKit)
 				try createPNG(qrCode: qrCode, outputFile: outputFile.unstyled)
+				#endif
 			}
 			
 			// Create SVG
 			try createSVG(qrCode: qrCode, outputFile: outputFile.styled)
 		}
 		switch generatorType {
+			#if canImport(CoreImage)
 			case .coreImage: try generate(using: CIQRCodeGenerator.self)
+			#endif
 			case .nayuki:    try generate(using: BCQRCodeGenerator.self)
 		}
 	}
@@ -92,7 +99,9 @@ struct QRGen {
 		addNameTag("m\(pixelMargin)", pixelMargin != 0)
 		addNameTag("r\(cornerRadius)", cornerRadius != 100 && style != .standard)
 		addNameTag("all", ignoreSafeAreas)
+		#if canImport(CoreImage)
 		addNameTag("CI", generatorType == .coreImage)
+		#endif
 		
 		let baseName = !outputURL.hasDirectoryPath ? outputURL.lastPathComponent : {
 			let formatter = DateFormatter()
@@ -111,12 +120,14 @@ struct QRGen {
 	}
 	
 	
+	#if canImport(AppKit)
 	private func createPNG<T: QRCodeProtocol>(qrCode: T, outputFile: URL) throws {
 		let outputFilePNG = outputFile.appendingPathExtension("png")
 		let cicontext = CIContext()
 		let ciimage = CIImage(cgImage: qrCode.cgimage)
 		try cicontext.writePNGRepresentation(of: ciimage, to: outputFilePNG, format: .RGBA8, colorSpace: ciimage.colorSpace!)
 	}
+	#endif
 	
 	
 	private func createSVG<T: QRCodeProtocol>(qrCode: T, outputFile: URL) throws {


### PR DESCRIPTION
Add compatibility for Swift installations on Linux where `AppKit`, `CoreImage` and `CoreGraphics` aren't available by disabling the `--coreimage` and `--png` options at compile time.